### PR TITLE
fixed logging when using fablib extensions 1.3.3

### DIFF
--- a/fabfed/provider/fabric/fabric_slice.py
+++ b/fabfed/provider/fabric/fabric_slice.py
@@ -22,6 +22,20 @@ class FabricSlice:
 
     def init(self):
         from fabrictestbed_extensions.fablib.fablib import fablib
+        from fabfed.util.utils import get_log_level, get_log_location
+
+        location = get_log_location()
+
+        if fablib.get_default_fablib_manager().get_log_file() != location:
+            self.logger.debug("Initializing fablib extensions logging ...")
+            fablib.get_default_fablib_manager().set_log_file(location)
+            fablib.get_default_fablib_manager().set_log_level(get_log_level())
+
+            for handler in logging.root.handlers.copy():
+                logging.root.removeHandler(handler)
+
+            for handler in self.logger.handlers:
+                logging.root.addHandler(handler)
 
         # noinspection PyBroadException
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fabric-fim==1.3.0
-fabrictestbed-extensions==1.3.1
+fabrictestbed-extensions==1.3.3
 python-chi
 sense-o-api==1.23
+ansible


### PR DESCRIPTION
no longer using root logger for fabfed. Root logger can be used by third party libraries. Example fablib extensions uses root logger