### PR TITLE
minor enhancements (docs, state, -init)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ fabfed sessions --help
 ```
 
 # <a name="operate"></a>Operation Instructions
-- [ ] Fabfed worflow configuration is specified across one or more <i>.fab<i> files. Fabfed does not care how these files  are named. Fabfed simply loads all the .fab configuration files, assembles them and parses the assembled configuration.  
-- [ ] Fabfed will pickup any file ending with the <b>.fab</b> extension in the directory specified by
+- Fabfed worflow configuration is specified across one or more <i>.fab<i> files. Fabfed does not care how these files  are named. Fabfed simply loads all the .fab configuration files, assembles them and parses the assembled configuration.  
+- Fabfed will pickup any file ending with the <b>.fab</b> extension in the directory specified by
 the <i>--config-dir</i>.  If this option is not present, the current directory is used. 
-- [ ] The --var-file option can be used to override the default value of any variable. It consists of a set of key-value pairs with each pair written as ```key: value```. At runtime, all variables found in an assembled configuration must have a value other than ```None```. The parser will halt and throw an exeption otherwise. 
-- [ ] The --session is a friendly name used to track a given workflow.  
-- [ ] Use the --help options shown above if in doubt. 
+- The --var-file option can be used to override the default value of any variable. It consists of a set of key-value pairs with each pair written as ```key: value```. At runtime, all variables found in an assembled configuration must have a value other than ```None```. The parser will halt and throw an exeption otherwise. 
+- The --session is a friendly name used to track a given workflow.  
+- Use the --help options shown above if in doubt. 
 
 ```
 fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -validate

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The FabFed is a Python library for a cross-testbed federation framework that (1)
 
 The FabFed code took the initial form from the Mobius API, and refactored and reinvented the slice modeling, user interface, data structure and  stitching workflows. 
 
-The example below showcases network stitching across providers, a [chi](https://www.chameleoncloud.org/) provider and a [fabric](https://portal.fabric-testbed.net/) provider. The configuration, while incomplete, highlights how fabfed-py expresses dependencies. In particular, line 12 states that the network labeled `fabric_network` gets its `vlan` from the `chi_network`. 
+The example below showcases network stitching across providers, a [chi](https://www.chameleoncloud.org/) provider and a [fabric](https://portal.fabric-testbed.net/) provider. The configuration, while incomplete, highlights how fabfed-py expresses dependencies.  
 
 - For more details, refer to fabfed's [workflow design](./docs/workflow_design.md)
 - For a complete example, refer to  [Fabric Chameleon Stitching](./examples/stitch)
@@ -26,7 +26,7 @@ The example below showcases network stitching across providers, a [chi](https://
   9       - fabric_network:
  10            provider: '{{ fabric.fabric_provider }}'
  11            site: 'STAR'
- 12            vlan: '{{ network.chi_network.vlans}}'
+ 12            stitch_with: '{{ network.chi_network }}'
 ```
 
 # <a name="install"></a>Installation
@@ -48,13 +48,17 @@ the <i>--config-dir</i>.  If this option is not present, the current directory i
 - [ ] Use the --help options shown above if in doubt. 
 
 ```
-fabfed workflow --config-dir some_dir --var-file some_var_file.yml --session some_session -validate
+fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -validate
 
-fabfed workflow --config-dir some_dir --var-file some_var_file.yml --session some_session  -apply
+fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -init [-summary] [-json]
 
-fabfed workflow --config-dir some_dir --var-file some_var_file.yml --session some_session -show
+fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -plan [-summary] [-json]
 
-fabfed workflow --config-dir some_dir --var-file some_var_file.yml --session some_session -destroy
+fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -apply
+
+fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -show [-summary] [-json]
+
+fabfed workflow --config-dir some_dir [--var-file some_var_file.yml] --session some_session -destroy
 
 fabfed sessions -show
 ```

--- a/examples/sense-aws/config.fab
+++ b/examples/sense-aws/config.fab
@@ -52,6 +52,9 @@ resource:
           peering: "{{ peering.my_peering }}"
           count: 1 
           stitch_with: '{{ network.fabric_network }}'
+          stitch_option: 
+              name: AGG4 
+
       - fabric_network:
           provider: '{{ fabric.fabric_provider }}'
           layer3: "{{ layer3.fab_layer }}"

--- a/fabfed/controller/controller.py
+++ b/fabfed/controller/controller.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union
+from typing import List, Union, Dict
 
 from fabfed.exceptions import ControllerException
 from fabfed.model.state import ProviderState
@@ -12,7 +12,8 @@ from ..util.config_models import ResourceConfig
 
 
 class Controller:
-    def __init__(self, *, config: WorkflowConfig, logger: logging.Logger, policy: Union[ProviderPolicy, None] = None):
+    def __init__(self, *, config: WorkflowConfig, logger: logging.Logger,
+                 policy: Union[Dict[str, ProviderPolicy], None] = None):
         self.config = config
         self.logger = logger
         self.provider_factory = None

--- a/fabfed/controller/policy.yaml
+++ b/fabfed/controller/policy.yaml
@@ -1,6 +1,7 @@
 fabric:
   stitch-port:
       - site: AWS
+        name: AGG4
         member-of:
           - AWS
         region:

--- a/fabfed/provider/api/provider.py
+++ b/fabfed/provider/api/provider.py
@@ -181,8 +181,10 @@ class Provider(ABC):
         net_states = [NetworkState(label=n.label, attributes=cleanup_attrs(vars(n))) for n in self.networks]
         node_states = [NodeState(label=n.label, attributes=cleanup_attrs(vars(n))) for n in self.nodes]
         service_states = [ServiceState(label=s.label, attributes=cleanup_attrs(vars(s))) for s in self.services]
+        pending = [res['label'] for res in self.pending]
+        pending_internal = [res['label'] for res in self.pending_internal]
         return ProviderState(self.label, dict(name=self.name), net_states, node_states, service_states,
-                             self.pending, self.pending_internal, self.failed)
+                             pending, pending_internal, self.failed)
 
     def list_networks(self) -> list:
         from tabulate import tabulate

--- a/fabfed/provider/fabric/fabric_network.py
+++ b/fabfed/provider/fabric/fabric_network.py
@@ -140,9 +140,13 @@ class NetworkBuilder:
             interface = self.stitching_net.interface
 
             if isinstance(interface, list):
-                interface = interface[0]
+                temp = [i for i in interface if isinstance(i, dict) and 'provider' in i]
+
+                if temp:
+                    interface = temp[0]
 
             if isinstance(interface, dict) and 'provider' in interface:
+                logger.info(f'Network {self.net_name} found stitching interface {interface}')
                 self.vlan = interface.get('vlan')
 
                 if not self.device:

--- a/fabfed/provider/sense/sense_network.py
+++ b/fabfed/provider/sense/sense_network.py
@@ -12,7 +12,7 @@ class SenseNetwork(Network):
         self.profile = profile
         self.layer3 = layer3
         self.peering = peering
-        self.interface = interfaces
+        self.interface = interfaces if interfaces is not None else []
         self.bandwidth = bandwidth
         self.switch_ports = []
         self.dtn = []
@@ -60,6 +60,19 @@ class SenseNetwork(Network):
 
         if 'CREATE - READY' not in status:
             raise Exception(f"Creation failed for {si_uuid} {status}")
+
+        if self.intents[0]['json']['service'] == 'vcn':
+            if "GCP" in self.intents[0]['json']['data']['gateways'][0]['type'].upper():
+                try:
+                    template_file = 'gcp-template.json'
+                    details = sense_utils.manifest_create(si_uuid=si_uuid, template_file=template_file)
+
+                    for node_details in details.get("Nodes", []):
+                        pairing_key = node_details.get('Pairing Key')
+                        self.interface.append(dict(id=pairing_key, provider="sense"))
+                        break
+                except:
+                    pass
 
         if self.intents[0]['json']['service'] == 'dnc':
             try:

--- a/fabfed/util/config_models.py
+++ b/fabfed/util/config_models.py
@@ -49,7 +49,7 @@ class ProviderConfig(BaseConfig):
         super().__init__(type, name, attrs)
 
 
-Dependency = namedtuple("Dependency", "key resource  attribute, is_external")
+Dependency = namedtuple("Dependency", "key resource attribute is_external")
 
 
 class ResourceConfig(BaseConfig):

--- a/fabfed/util/constants.py
+++ b/fabfed/util/constants.py
@@ -32,7 +32,6 @@ class Constants:
     RES_NET_POOL_START = "pool_start"
     RES_NET_POOL_END = "pool_end"
     RES_NET_GATEWAY = "gateway"
-    RES_NET_CALLBACK = "callback"
     RES_SUBNET = 'subnet'
     RES_LAYER3 = 'layer3'
     RES_PEER_LAYER3 = 'peer_layer3'
@@ -40,6 +39,7 @@ class Constants:
     RES_LAYER3_DHCP_END = 'ip_end'
 
     RES_INTERFACES = 'interface'
+    RES_NODES = 'node'
     RES_BANDWIDTH = "bandwidth"
     RES_INDEX = 'index'
 

--- a/fabfed/util/state.py
+++ b/fabfed/util/state.py
@@ -127,7 +127,10 @@ def load_states(friendly_name) -> List[ProviderState]:
     if os.path.exists(file_path):
         with open(file_path, 'r') as stream:
             try:
-                return yaml.load(stream, Loader=get_loader())
+                ret = yaml.load(stream, Loader=get_loader())
+
+                if ret is not None:
+                    return ret
             except Exception as e:
                 from fabfed.exceptions import StateException
 
@@ -142,11 +145,16 @@ def save_states(states: List[ProviderState], friendly_name):
     from fabfed.model.state import get_dumper
 
     file_path = os.path.join(get_base_dir(friendly_name), friendly_name + '.yml')
+    temp_file_path = file_path + ".temp"
 
-    with open(file_path, "w") as stream:
+    with open(temp_file_path, "w") as stream:
         try:
             stream.write(yaml.dump(states, Dumper=get_dumper()))
         except Exception as e:
             from fabfed.exceptions import StateException
 
-            raise StateException(f'Exception while saving state at {file_path}:{e}')
+            raise StateException(f'Exception while saving state at temp file {temp_file_path}:{e}')
+
+    import shutil
+
+    shutil.move(temp_file_path, file_path)

--- a/fabfed/util/utils.py
+++ b/fabfed/util/utils.py
@@ -34,6 +34,9 @@ def build_parser(*, manage_workflow, manage_sessions):
                                  required=False)
     workflow_parser.add_argument('-s', '--session', type=str, default='',
                                  help='friendly session name to help track a workflow', required=True)
+    workflow_parser.add_argument('-p', '--policy-file', type=str, default='',
+                                 help="Yaml stitching policy file",
+                                 required=False)
     workflow_parser.add_argument('-validate', action='store_true', default=False,
                                  help='assembles and validates all .fab files  in the config directory')
     workflow_parser.add_argument('-apply', action='store_true', default=False, help='create resources')

--- a/tools/fabfed.py
+++ b/tools/fabfed.py
@@ -74,7 +74,7 @@ def manage_workflow(args):
         config = WorkflowConfig(dir_path=args.config_dir, var_dict=var_dict)
         controller = Controller(config=config, logger=logger)
         controller.init(session=args.session, provider_factory=default_provider_factory)
-        sutil.dump_resources(controller.resources, args.json)
+        sutil.dump_resources(resources=controller.resources, to_json=args.json, summary=args.summary)
         return
 
     if args.plan:
@@ -89,53 +89,12 @@ def manage_workflow(args):
             logger.error(f"Exceptions while adding resources ... {e}")
 
         states = controller.get_states()
-        sutil.dump_states(states, args.json)
+        sutil.dump_states(states, args.json, args.summary)
         return
 
     if args.show:
         states = sutil.load_states(args.session)
-        sutil.dump_states(states, args.json)
-        return
-
-    if args.summary:
-        states = sutil.load_states(args.session)
-        temp = []
-
-        for provider_state in states:
-            for node_state in provider_state.node_states:
-                attributes = dict()
-                props = ['mgmt_ip', 'user', 'site', 'state', 'id', "dataplane_ipv4", "dataplane_ipv6"]
-
-                for prop in props:
-                    if prop in node_state.attributes:
-                        attributes[prop] = node_state.attributes[prop]
-
-                node_state.attributes = attributes
-                temp.append(node_state)
-
-            for network_state in provider_state.network_states:
-                attributes = dict()
-                props = ['id', 'name', 'interface', 'site', 'state', 'profile', "dtn", 'layer3']
-
-                for prop in props:
-                    if prop in network_state.attributes:
-                        attributes[prop] = network_state.attributes[prop]
-
-                network_state.attributes = attributes
-                temp.append(network_state)
-
-            for service_state in provider_state.service_states:
-                attributes = dict()
-                props = ['name', 'image']
-
-                for prop in props:
-                    if prop in service_state.attributes:
-                        attributes[prop] = service_state.attributes[prop]
-
-                service_state.attributes = attributes
-                temp.append(service_state)
-
-        sutil.dump_states(temp, args.json)
+        sutil.dump_states(states, args.json, args.summary)
         return
 
     if args.destroy:

--- a/tools/fabfed.py
+++ b/tools/fabfed.py
@@ -13,6 +13,10 @@ def manage_workflow(args):
 
     var_dict = utils.load_vars(args.var_file) if args.var_file else {}
 
+    from fabfed.controller.policy_helper import load_policy
+
+    policy = load_policy(policy_file=args.policy_file) if args.policy_file else {}
+
     if args.validate:
         try:
             WorkflowConfig(dir_path=args.config_dir, var_dict=var_dict)
@@ -26,7 +30,7 @@ def manage_workflow(args):
         config = WorkflowConfig(dir_path=args.config_dir, var_dict=var_dict)
 
         try:
-            controller = Controller(config=config, logger=logger)
+            controller = Controller(config=config, logger=logger, policy=policy)
         except Exception as e:
             logger.error(f"Exceptions while initializing controller .... {e}")
             sys.exit(1)
@@ -72,14 +76,14 @@ def manage_workflow(args):
 
     if args.init:
         config = WorkflowConfig(dir_path=args.config_dir, var_dict=var_dict)
-        controller = Controller(config=config, logger=logger)
+        controller = Controller(config=config, logger=logger, policy=policy)
         controller.init(session=args.session, provider_factory=default_provider_factory)
         sutil.dump_resources(resources=controller.resources, to_json=args.json, summary=args.summary)
         return
 
     if args.plan:
         config = WorkflowConfig(dir_path=args.config_dir, var_dict=var_dict)
-        controller = Controller(config=config, logger=logger)
+        controller = Controller(config=config, logger=logger, policy=policy)
         controller.init(session=args.session, provider_factory=default_provider_factory)
         states = sutil.load_states(args.session)
 
@@ -103,7 +107,7 @@ def manage_workflow(args):
         try:
             if states:
                 config = WorkflowConfig(dir_path=args.config_dir, var_dict=var_dict)
-                controller = Controller(config=config, logger=logger)
+                controller = Controller(config=config, logger=logger, policy=policy)
                 controller.init(session=args.session, provider_factory=default_provider_factory)
                 controller.delete(provider_states=states)
         except ControllerException as e:


### PR DESCRIPTION
- started documentation (Updated README)
- summary now only works in conjunction with -plan, -show, -init
- enhanced the -init option
- made sure state is not overwritten during failures by introducing temp file
- the stitch info can be selected by using a policy stitch port name or a policy group name
- refactored fabric_network builder to simplify sense-gcp integration
- only labels and saved for internal and pending resources to avoid yaml serialization complications and to keep the state less verbose 