### PR TITLE
using dashes for the facility_port name when peering with sense

### DIFF
--- a/fabfed/provider/fabric/fabric_network.py
+++ b/fabfed/provider/fabric/fabric_network.py
@@ -211,7 +211,7 @@ class NetworkBuilder:
             logger.info(f"Creating Facility Port:PeerLabels: {peer_labels}")
 
             facility_port = self.slice_object.add_facility_port(
-                name='Cloud_Facility_' + cloud,
+                name='Cloud-Facility-' + cloud,
                 site=cloud,
                 labels=labels,
                 peer_labels=peer_labels,


### PR DESCRIPTION
Changed to Cloud-Facility-AWS. Before we were using underscores.

Tested sense with AWS using:

- fabrictestbed-extensions==1.5.0
- site=RENC
- device_name=agg4.ashb.net.internet2.edu
- local_name=HundredGigE0/0/0/7