### PR TITLE
Fabric slice post stable ok

### DIFF
--- a/fabfed/provider/fabric/fabric_network.py
+++ b/fabfed/provider/fabric/fabric_network.py
@@ -30,10 +30,10 @@ class FabricNetwork(Network):
         self.interface = []
 
         if self.peering:
-            cloud = self.peering.attributes.get(Constants.RES_CLOUD_FACILITY)
+            # cloud = self.peering.attributes.get(Constants.RES_CLOUD_FACILITY)
 
-            if cloud != "AWS":
-                raise Exception(f"unsupported cloud {cloud}")
+            # if cloud != "AWS":
+            #    raise Exception(f"unsupported cloud {cloud}")
 
             account_id = self.peering.attributes[Constants.RES_CLOUD_ACCOUNT]
             key = self.slice_name + "-" + account_id

--- a/fabfed/provider/fabric/fabric_slice.py
+++ b/fabfed/provider/fabric/fabric_slice.py
@@ -229,26 +229,76 @@ class FabricSlice:
 
         self.provider._networks = temp
 
-    def _setup_networks(self, node, v4net_name, v6net_name):
-        v4_net = self.slice_object.get_network(name=v4net_name)
-        v4_net_available_ips = v4_net.get_available_ips()
-        v6_net = self.slice_object.get_network(name=v6net_name)
-        v6_net_available_ips = v6_net.get_available_ips()
+    def _ensure_management_ips(self):
+        for attempt in range(self.retry):
+            mngmt_ips = []
+            from fabrictestbed_extensions.fablib.fablib import fablib
 
-        iface_v4 = node.get_interface(network_name=v4net_name)
-        iface_v6 = node.get_interface(network_name=v6net_name)
+            self.slice_object = fablib.get_slice(name=self.provider.name)
 
-        # TODO ADD WARNINGS ....
-        if v4_net_available_ips:
-            addr_v4 = v4_net_available_ips.pop(0)
-            iface_v4.ip_addr_add(addr=addr_v4, subnet=v4_net.get_subnet())
+            for node in self.nodes:
+                delegate = self.slice_object.get_node(node.name)
+                mgmt_ip = delegate.get_management_ip()
 
-        if v6_net_available_ips:
-            addr_v6 = v6_net_available_ips.pop(0)
-            iface_v6.ip_addr_add(addr=addr_v6, subnet=v6_net.get_subnet())
+                if mgmt_ip:
+                    mngmt_ips.append(mgmt_ip)
 
-        node.ip_route_add(subnet=FABRIC_PRIVATE_IPV4_SUBNET, gateway=v4_net.get_gateway())
-        node.ip_route_add(subnet=FABRIC_PUBLIC_IPV6_SUBNET, gateway=v6_net.get_gateway())
+            if len(self.nodes) == len(mngmt_ips):
+                self.logger.info(f"Got All management ips for slice {self.provider.label}:{mngmt_ips}")
+                break
+
+            if attempt == self.retry:
+                self.logger.warning(f"Giving up on checking node management ips ...slice "
+                                    f"{self.provider.label} {self.nodes}:{mngmt_ips}:")
+                break
+
+            import time
+
+            self.logger.info(
+                f"Going to sleep. Will try checking node management ips ... slice {self.provider.label}")
+
+            time.sleep(2)
+
+    def _handle_node_networking(self):
+        from fabrictestbed_extensions.fablib.fablib import fablib
+        from . import fabric_slice_helper
+
+        self._ensure_management_ips()
+
+        if INCLUDE_FABNETS:
+            self.slice_object = fablib.get_slice(name=self.provider.name)
+            for node in self.nodes:
+                fabric_slice_helper.setup_fabric_networks(self.slice_object, node, node.v4net_name, node.v6net_name)
+
+        if self.networks:
+            from ipaddress import IPv4Network
+            # self.slice_object = fablib.get_slice(name=self.provider.name)
+            available_ips = self.networks[0].available_ips()
+
+            if available_ips and self.networks[0].subnet:
+                net_name = self.networks[0].name
+                subnet = IPv4Network(self.networks[0].subnet)
+
+                for node in self.nodes:
+                    node_addr = available_ips.pop(0)
+                    fabric_slice_helper.add_ip_address_to_network(self.slice_object,
+                                                                  node, net_name, node_addr, subnet, self.retry)
+
+            gateway = self.networks[0].gateway
+            # self.slice_object = fablib.get_slice(name=self.provider.name)
+
+            if gateway and self.networks[0].peer_layer3:
+                for peer_layer3 in self.networks[0].peer_layer3:
+                    subnet = peer_layer3.attributes.get(Constants.RES_SUBNET)
+
+                    if subnet:
+                        vpc_subnet = fabric_slice_helper.to_vpc_subnet(subnet)
+
+                        for node in self.nodes:
+                            fabric_slice_helper.add_route(self.slice_object, node, vpc_subnet, gateway, self.retry)
+
+        self._reload_nodes()
+        self._reload_networks()
 
     def create_resource(self, *, resource: dict):
         label = resource.get(Constants.LABEL)
@@ -265,6 +315,8 @@ class FabricSlice:
                 self.logger.debug(f"already provisioned. {self.name}: state={state}")
 
             if not self.notified_create and self.resource_listener:
+                self._handle_node_networking()
+
                 for node in self.nodes:
                     self.resource_listener.on_created(source=self, provider=self, resource=node)
 
@@ -280,92 +332,13 @@ class FabricSlice:
 
         self._submit_and_wait()
         self.slice_created = True
-        self.logger.info(f"will check for management ips ...: {self.name}")
-        for attempt in range(self.retry):
-            mngmt_ips = []
-            from fabrictestbed_extensions.fablib.fablib import fablib
 
-            self.slice_object = fablib.get_slice(name=self.provider.name)
+        self.logger.info(f"Going to sleep. DEEP. slice {self.provider.label}")
+        import time
+        time.sleep(30)
+        self.logger.info(f"Back from sleeping ... slice {self.provider.label}")
 
-            for node in self.nodes:
-                delegate = self.slice_object.get_node(node.name)
-                mgmt_ip = delegate.get_management_ip()
-
-                if mgmt_ip:
-                    mngmt_ips.append(mgmt_ip)
-
-            if len(self.nodes) == len(mngmt_ips):
-                self.logger.info(f"Got All management ips for slice {self.provider.label}")
-                break
-
-            if attempt == self.retry:
-                self.logger.warning(f"Giving up on checking node management ips ...slice "
-                                    f"{self.provider.label} {self.nodes}:{mngmt_ips}:")
-                break
-
-            import time
-
-            self.logger.info(
-                f"Going to sleep. Will try checking node management ips ...slice {self.provider.label}")
-
-            time.sleep(2)
-
-        if INCLUDE_FABNETS:
-            for node in self.nodes:
-                delegate = self.slice_object.get_node(node.name)
-                self._setup_networks(delegate, node.v4net_name, node.v6net_name)
-
-        if self.networks:
-            from ipaddress import IPv4Network
-            available_ips = self.networks[0].available_ips()
-
-            if available_ips and self.networks[0].subnet:
-                net_name = self.networks[0].name
-                subnet = IPv4Network(self.networks[0].subnet)
-
-                for node in self.nodes:
-                    delegate = self.slice_object.get_node(node.name)
-
-                    try:
-                        iface = delegate.get_interface(network_name=net_name)
-                        node_addr = available_ips.pop(0)
-                        iface.ip_addr_add(addr=node_addr, subnet=subnet)
-                    except:
-                        iface = delegate.get_interface(network_name=net_name + "_aux")
-                        node_addr = available_ips.pop(0)
-                        iface.ip_addr_add(addr=node_addr, subnet=subnet)
-
-            gateway = self.networks[0].gateway
-
-            if gateway and self.networks[0].peer_layer3:
-                for peer_layer3 in self.networks[0].peer_layer3:
-                    subnet = peer_layer3.attributes.get(Constants.RES_SUBNET)
-
-                    if not subnet:
-                        continue
-
-                    from ipaddress import IPv4Network
-                    subnet = IPv4Network(subnet)
-                    vpc_subnet = subnet
-
-                    for i in [8, 4, 2]:
-                        if subnet.prefixlen - i > 0:
-                            vpc_subnet = subnet.supernet(i)
-                            break
-
-                    command = f"sudo ip route add {vpc_subnet} via {gateway}"
-
-                    for node in self.nodes:
-                        try:
-                            delegate = self.slice_object.get_node(node.name)
-                            _, _ = delegate.execute(command)
-                        except:
-                            import traceback
-
-                            traceback.print_exc()
-
-        self._reload_nodes()
-        self._reload_networks()
+        self._handle_node_networking()
 
         if self.resource_listener:
             for node in self.nodes:

--- a/fabfed/provider/fabric/fabric_slice_helper.py
+++ b/fabfed/provider/fabric/fabric_slice_helper.py
@@ -1,0 +1,118 @@
+import time
+
+from fabfed.util.utils import get_logger
+from .fabric_constants import *
+
+logger = get_logger()
+
+
+def has_ip_address(slice_delegate, node, addr):
+    addrs = []
+    delegate = slice_delegate.get_node(node.name)
+    ip_addr_list = delegate.ip_addr_list(output='json', update=False)
+
+    if ip_addr_list:
+        for ip_addr in ip_addr_list:
+            for addr_info in ip_addr['addr_info']:
+                addrs.append(addr_info['local'])
+
+    return str(addr) in addrs
+
+
+def has_ip_route(slice_delegate, node, subnet, gateway):
+    delegate = slice_delegate.get_node(node.name)
+    routes = delegate.get_ip_routes()
+
+    if routes:
+        for route in routes:
+            if str(subnet) == route.get('dst') and str(gateway) == route.get('gateway'):
+                return True
+
+    return False
+
+
+def to_vpc_subnet(subnet: str):
+    from ipaddress import IPv4Network
+
+    subnet = IPv4Network(subnet)
+    vpc_subnet = subnet
+
+    for i in [8, 4, 2]:
+        if subnet.prefixlen - i > 0:
+            vpc_subnet = subnet.supernet(i)
+            break
+
+    return vpc_subnet
+
+
+def setup_fabric_networks(slice_delegate, node, v4net_name, v6net_name):
+    logger.info(f'setting up ipv4 and ipv6 fabric networks:{node.name}')
+    delegate = slice_delegate.get_node(node.name)
+    v4_net = slice_delegate.get_network(name=v4net_name)
+    v4_net_available_ips = v4_net.get_available_ips()
+    v6_net = slice_delegate.get_network(name=v6net_name)
+    v6_net_available_ips = v6_net.get_available_ips()
+    iface_v4 = delegate.get_interface(network_name=v4net_name)
+    iface_v6 = delegate.get_interface(network_name=v6net_name)
+
+    if v4_net_available_ips:
+        addr_v4 = v4_net_available_ips.pop(0)
+        iface_v4.ip_addr_add(addr=addr_v4, subnet=v4_net.get_subnet())
+
+    if v6_net_available_ips:
+        addr_v6 = v6_net_available_ips.pop(0)
+        iface_v6.ip_addr_add(addr=addr_v6, subnet=v6_net.get_subnet())
+
+    delegate.ip_route_add(subnet=FABRIC_PRIVATE_IPV4_SUBNET, gateway=v4_net.get_gateway())
+    delegate.ip_route_add(subnet=FABRIC_PUBLIC_IPV6_SUBNET, gateway=v6_net.get_gateway())
+
+
+def add_ip_address_to_network(slice_delegate, node, net_name, node_addr, subnet, retry):
+    delegate = slice_delegate.get_node(node.name)
+
+    if has_ip_address(slice_delegate, node, node_addr):
+        logger.info(f'already exists when adding ip addr: {node_addr}')
+        return
+
+    for attempt in range(retry):
+        try:
+            iface = delegate.get_interface(network_name=net_name)
+            logger.info(f'adding ip addr: {iface}: {net_name}:{node.name}:attempt={attempt + 1}')
+            iface.ip_addr_add(addr=node_addr, subnet=subnet)
+        except:
+            iface = delegate.get_interface(network_name=net_name + "_aux")
+            logger.info(f'adding ip addr {node_addr}:{subnet}: {net_name + "_aux"}:{node.name}:attempt={attempt + 1}')
+            iface.ip_addr_add(addr=node_addr, subnet=subnet)
+
+        if has_ip_address(slice_delegate, node, node_addr):
+            logger.info(f'added ip addr: {node_addr}')
+            return
+
+        if attempt == retry:
+            break
+
+        time.sleep(2)
+
+    logger.warning(f'Giving up: adding ip addr: {node_addr} after {retry} attempts')
+
+
+def add_route(slice_delegate, node, vpc_subnet, gateway, retry):
+    if has_ip_route(slice_delegate, node, vpc_subnet, gateway):
+        logger.info(f"already exists when adding route: {vpc_subnet}:gateway={gateway}")
+        return
+
+    for attempt in range(retry):
+        logger.info(f"adding route: {vpc_subnet}:gateway={gateway}:attempt={attempt + 1}")
+        delegate = slice_delegate.get_node(node.name)
+        delegate.ip_route_add(subnet=vpc_subnet, gateway=gateway)
+
+        if has_ip_route(slice_delegate, node, vpc_subnet, gateway):
+            logger.info(f"added: {vpc_subnet}:gateway={gateway}:attempt={attempt + 1}")
+            return
+
+        if attempt == retry:
+            break
+
+        time.sleep(2)
+
+    logger.warning(f"Giving up:adding route: {vpc_subnet}:gateway={gateway} after {retry} attempts")


### PR DESCRIPTION
In Fabric we now create routes and ip addresses if for some reason they were not created post submit.
This comes in handy if there were networking errors after slice has been declared OK 
or if a user uses a key interrupt Ctrl-C

Tested using sense-aws.