### PR TITLE
tested sense gcp with FABRIC-GCP-INTERCON

### DIFF
--- a/examples/sense-gcp/config.fab
+++ b/examples/sense-gcp/config.fab
@@ -57,8 +57,10 @@ resource:
           peering: "{{ peering.my_peering }}"
           count: 1 
           stitch_with: '{{ network.fabric_network }}'
+          profile: FABRIC-GCP-INTERCON
           stitch_option:
-              profile: FABRIC-GCP-INTERCON
+              group_name: GCP
+              # profile: GCP-INTERCONN
 
       - fabric_network:
           provider: '{{ fabric.fabric_provider }}'


### PR DESCRIPTION
Tested deploying sense gcp using FABRIC-GCP-INTERCON and ssh.
```
ssh -i ~/FABRIC/kp-sense-private kpsense@XXXX

kp-sense@vm-fcc70f98-693f-44bf-8a98-bd9c1ce0fe54---vm-1:~$ cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.2 LTS (Jammy Jellyfish)"
UBUNTU_CODENAME=jammy
```