### PR TITLE
making ansible scripts and json files for stitching policy are packaged

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include fabfed/config/*.yml
 include requirements.txt
-include Readme.md
+include README.md
 include LICENSE
+recursive-include fabfed *.json *.yml *.j2


### PR DESCRIPTION
@disprosium8 

It seems that non python files are missing from the distribution on pypi.
This should fix it.