### PR TITLE
Tested fablib 1.4 and allowed for fabric nodes to point network. 

### DIFF
--- a/cicd/test_configs/fabric_l2_vpn/config.fab
+++ b/cicd/test_configs/fabric_l2_vpn/config.fab
@@ -24,14 +24,14 @@ resource:
             image: default_rocky_8
             nic_model: NIC_Basic
             flavor: {'cores': 2, 'ram': 8, 'disk': 10}
-      - ubuntu_node:
+      - other_node:
             provider:  '{{ fabric.fabric_provider }}'
             site: '{{ var.fabric_site }}' 
             count: 1
-            image: default_ubuntu_22
+            image: default_rocky_8
   - network:
       - fabric_network:
           provider: '{{ fabric.fabric_provider }}'
           layer3: "{{ layer3.my_layer }}"
-          interface: [ '{{ node.rocky_node }}', '{{ node.ubuntu_node }}' ]
+          interface: [ '{{ node.rocky_node }}', '{{ node.other_node }}' ]
           count: 1

--- a/cicd/test_configs/fabric_l2_vpn/config.fab
+++ b/cicd/test_configs/fabric_l2_vpn/config.fab
@@ -24,14 +24,9 @@ resource:
             image: default_rocky_8
             nic_model: NIC_Basic
             flavor: {'cores': 2, 'ram': 8, 'disk': 10}
-      - other_node:
-            provider:  '{{ fabric.fabric_provider }}'
-            site: '{{ var.fabric_site }}' 
-            count: 1
-            image: default_rocky_8
+            network: '{{ network.fabric_network }}'
   - network:
       - fabric_network:
           provider: '{{ fabric.fabric_provider }}'
           layer3: "{{ layer3.my_layer }}"
-          interface: [ '{{ node.rocky_node }}', '{{ node.other_node }}' ]
           count: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fabrictestbed-extensions==1.6.3
+fabrictestbed-extensions==1.6.5
 python-chi
 sense-o-api==1.26
 ansible==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fabrictestbed-extensions==1.6.5
+fabrictestbed-extensions==1.6.4
 python-chi
 sense-o-api==1.26
 ansible==7.1.0


### PR DESCRIPTION
This works now and it is the same design as cloudlab and chameleon ....

```
resource:
  - node:
      - rocky_node:
            provider:  '{{ fabric.fabric_provider }}'
            site: '{{ var.fabric_site }}'
            count: 1
            image: default_rocky_8
            nic_model: NIC_Basic
            flavor: {'cores': 2, 'ram': 8, 'disk': 10}
            network: '{{ network.fabric_network }}'
  - network:
      - fabric_network:
          provider: '{{ fabric.fabric_provider }}'
          layer3: "{{ layer3.my_layer }}"
          count: 1
```