### PR TITLE
Avoid waiting on node creation when creating sense/fabric networks

### DIFF
--- a/fabfed/provider/sense/manifests/gcp-pairing-key-template.json
+++ b/fabfed/provider/sense/manifests/gcp-pairing-key-template.json
@@ -1,0 +1,5 @@
+{
+  "Pairing Key": "?pairing_key?",
+  "sparql": "SELECT DISTINCT ?pairing_key WHERE {?vpc nml:hasBidirectionalPort ?vpngw. ?vpngw nml:name ?cloud_router. ?vpngw nml:isAlias ?vlan_attachment. ?vlan_attachment mrs:hasNetworkStatus \"pending_partner\". ?vlan_attachment mrs:hasNetworkAddress ?pairing_key_na. ?pairing_key_na mrs:type \"pairing-key\". ?pairing_key_na mrs:value ?pairing_key.}",
+  "required": "true"
+}

--- a/fabfed/provider/sense/sense_node.py
+++ b/fabfed/provider/sense/sense_node.py
@@ -26,11 +26,12 @@ class SenseNode(Node):
         if not si_uuid:
             raise SenseException(f"Instance not found by alias={self.network}")
 
-        status = sense_utils.instance_get_status(si_uuid=si_uuid)
+        statuses = ('CREATE - READY', 'REINSTATE - READY')
+        status = sense_utils.wait_for_instance_operate(si_uuid=si_uuid, statuses=statuses)
 
-        if status != 'CREATE - READY':
-            raise SenseException(f"Instance is not ready:status={status}")
-        
+        if status not in statuses:
+            raise SenseException(f"Instance is not in ready state:status={status}")
+
         """ retrieve the gateway type from intents """
         instance_dict = sense_utils.service_instance_details(si_uuid=si_uuid, alias=self.network)
         gateway_type = instance_dict.get("intents")[0]['json']['data']['gateways'][0]['type'].upper()

--- a/fabfed/provider/sense/sense_provider.py
+++ b/fabfed/provider/sense/sense_provider.py
@@ -136,8 +136,13 @@ class SenseProvider(Provider):
 
         from .sense_network import SenseNetwork
 
+        saved_interfaces = self.retrieve_attribute_from_saved_state(resource, net_name, attribute='interface')
+        if not isinstance(saved_interfaces, list):
+            saved_interfaces = [saved_interfaces]
+
         net = SenseNetwork(label=label, name=net_name, profile=profile,
-                           bandwidth=bandwidth, layer3=layer3, peering=peering, interfaces=interfaces)
+                           bandwidth=bandwidth, layer3=layer3, peering=peering, interfaces=interfaces,
+                           saved_interfaces=saved_interfaces)
 
         self._networks.append(net)
 


### PR DESCRIPTION
- sense networks are 'declared created' when sense slice enters CreateCommitted and when relevant info like gcp pairing key is available. This means the fabric slice will proceed more quickly without waiting for sense nodes to be created (CreateReady)

- fabric networks are 'declared created' when fabric network slivers are active. This means sense-aws/native-aws slice will proceed more quickly without waiting for fabric nodes to be created (StableOk)

https://github.com/fabric-testbed/fabfed/issues/154